### PR TITLE
Do not mark format of imageData as byte[], or it becomes this type

### DIFF
--- a/bridge-api/definitions/consent_signature.yml
+++ b/bridge-api/definitions/consent_signature.yml
@@ -27,7 +27,6 @@ properties:
         description: The participant's date of birth in ISO 8601 format (YYYY-MM-DD).
     imageData:
         type: string
-        format: binary
         description: Base 64 encoded image of the participant's signature. If `imageData` is supplied, 
             `imageMimeType` must also be supplied.
     imageMimeType:


### PR DESCRIPTION
 (not a string) which is not compatible with our existing SDK.
