### PR TITLE
Adding start/end date query parameters to the getAccountSummaries() call

### DIFF
--- a/bridge-api/definitions/index.yml
+++ b/bridge-api/definitions/index.yml
@@ -177,6 +177,8 @@ ScheduledActivityList:
     $ref: ./paged_resources/scheduled_activity.yml
 SchedulePlanList:
     $ref: ./paged_resources/schedule_plan.yml
+StringList:
+    $ref: ./paged_resources/string.yml
 StudyList:
     $ref: ./paged_resources/study.yml
 StudyConsentList:

--- a/bridge-api/definitions/paged_resources/account_summary.yml
+++ b/bridge-api/definitions/paged_resources/account_summary.yml
@@ -15,6 +15,14 @@ properties:
     emailFilter:
         type: string
         description: The email filter submitted to the server
+    startDate:
+        type: string 
+        format: date-time
+        description: The start date filter applied to the createdOn timestamp of the account.
+    endDate:
+        type: string 
+        format: date-time
+        description: The end date filter applied to the createdOn timestamp of the account.
     total:
         type: integer
         description: The total number of records that match the criteria (may exceed page size)

--- a/bridge-api/paths/participants/v3_participants.yml
+++ b/bridge-api/paths/participants/v3_participants.yml
@@ -23,6 +23,8 @@ get:
           type: string
           required: false
           in: query
+        - $ref: ../../index.yml#/parameters/startDate
+        - $ref: ../../index.yml#/parameters/endDate
     responses:
         200:
             description: OK


### PR DESCRIPTION
This needs to be rolled out in BridgePF before it can be added to the documentation, SDK, etc.