### PR TITLE
These fields are definitely read-only, even for testing. At least one…

### DIFF
--- a/bridge-api/definitions/consent_signature.yml
+++ b/bridge-api/definitions/consent_signature.yml
@@ -37,17 +37,20 @@ properties:
             must also be supplied.
     consentCreatedOn:
         type: string
+        readOnly: true
         description: |
             The timestamp of the version of the subpopulation consent that was 
             presented to the participant for agreement. 
         format: date-time
     signedOn:
         type: string
+        readOnly: true
         description: |
             The date and time of agreement to this consent.
         format: date-time
     withdrewOn:
         type: string
+        readOnly: true
         description: |
             If this consent is later revoked, this is the date of revocation.
         format: date-time


### PR DESCRIPTION
… customer has tried to supply these timestamps and gotten an error back from the server (we know about this issue: the timestamps don't convert to longs).