### PR TITLE
 delete schema API is now an Admin API (only to be used by integ tests for test cleanup)

### DIFF
--- a/bridge-api/paths/index.yml
+++ b/bridge-api/paths/index.yml
@@ -177,6 +177,8 @@
 # APIs for getting entities across studies
 /v3/studies/{studyId}/surveys/published:
     $ref: ./studies/v3_studies_studyId_surveys_published.yml
+/v3/studies/{studyId}/uploadschemas/{schemaId}:
+    $ref: ./studies/v3_studies_studyId_uploadschemas_schemaId.yml
 /v3/studies/{studyId}/uploadschemas/{schemaId}/revisions/{revision}:
     $ref: ./studies/v3_studies_studyId_uploadschemas_schemaId_revisions_revision.yml
 /v3/studies/{studyId}/reports/{identifier}:

--- a/bridge-api/paths/studies/v3_studies_studyId_uploadschemas_schemaId.yml
+++ b/bridge-api/paths/studies/v3_studies_studyId_uploadschemas_schemaId.yml
@@ -1,0 +1,18 @@
+delete:
+    operationId: deleteAllRevisionsOfUploadSchema
+    summary: Delete all revisions of an upload schema
+    tags: 
+        - Upload Schemas
+        - _For Admins
+    security:
+        -   BridgeSecurity: []
+    parameters:
+        - $ref: ../../index.yml#/parameters/studyId
+        - $ref: ../../index.yml#/parameters/schemaId
+    responses:
+        200:
+            $ref: ../../responses/200_message.yml
+        401:
+            $ref: ../../responses/401.yml
+        403:
+            $ref: ../../responses/403_not_admin.yml

--- a/bridge-api/paths/uploadschemas/v3_uploadschemas_schemaId.yml
+++ b/bridge-api/paths/uploadschemas/v3_uploadschemas_schemaId.yml
@@ -17,20 +17,3 @@ get:
             $ref: ../../responses/401.yml
         403:
             $ref: ../../responses/403_not_developer.yml
-delete:
-    operationId: deleteAllRevisionsOfUploadSchema
-    summary: Delete all revisions of an upload schema
-    tags: 
-        - Upload Schemas
-        - _For Developers
-    security:
-        -   BridgeSecurity: []
-    parameters:
-        - $ref: ../../index.yml#/parameters/schemaId
-    responses:
-        200:
-            $ref: ../../responses/200_message.yml
-        401:
-            $ref: ../../responses/401.yml
-        403:
-            $ref: ../../responses/403_not_developer.yml

--- a/bridge-api/paths/uploadschemas/v3_uploadschemas_schemaId_revisions_revision.yml
+++ b/bridge-api/paths/uploadschemas/v3_uploadschemas_schemaId_revisions_revision.yml
@@ -19,21 +19,3 @@ get:
             $ref: ../../responses/401.yml
         403:
             $ref: ../../responses/403_not_developer_worker.yml
-delete:
-    operationId: deleteUploadSchema
-    summary: Delete a revision of an upload schema
-    tags: 
-        - Upload Schemas
-        - _For Developers
-    security:
-        -   BridgeSecurity: []
-    parameters:
-        - $ref: ../../index.yml#/parameters/schemaId
-        - $ref: ../../index.yml#/parameters/revision
-    responses:
-        200:
-            $ref: ../../responses/200_message.yml
-        401:
-            $ref: ../../responses/401.yml
-        403:
-            $ref: ../../responses/403_not_developer.yml


### PR DESCRIPTION
See https://github.com/Sage-Bionetworks/BridgePF/pull/1313

Note that there are currently changes in BridgeDocs that haven't been merged into JavaSDK:
https://github.com/Sage-Bionetworks/BridgeDocs/pull/87

These changes are breaking changes that are non-trivial to resolve. This is blocking a critical devops fix.

Testing done:
* verify.sh
* copied swagger.json to JavaSDK and verified the only changes are from the aforementioned pull request