### PR TITLE
Upload doc updates: createdOn, published, more mutable schemas

### DIFF
--- a/_articles/bundled_zip_file_uploads.md
+++ b/_articles/bundled_zip_file_uploads.md
@@ -45,7 +45,7 @@ Bundles must include a JSON file called info.json, which looks like:
 |Attribute Name|Description|
 |---|---|
 |files|(V1 Legacy only) List of files in this bundle (excluding info.json). Each entry contains a filename and a timestamp. The timestamp is a string in ISO8601 format and corresponds to when the health data measurement was recorded. If the data was measured over a long period of time, the timestamp should represent when the data was last measured and written. This information is used to generate the createdOn field in the health data record.<br /><br />Similar to timestamp data as described in [Schemas](schemas.html), apps should refrain from "canonicalizing" to a default timezone such as UTC, as this is a loss of data.|
-|createdOn|(V2 Generic only) Timestamp string in ISO8601 format, corresponding to when the health data measurement was recorded, similar to the timestamp in V1 Legacy "files" attribute.|
+|createdOn|Timestamp string in ISO8601 format, corresponding to when the health data measurement was recorded, similar to the timestamp in V1 Legacy "files" attribute.<br /><br />If both this attribute and "files" is present, this attribute takes precedence.|
 |dataFilename|(V2 Generic only) Name of file in the bundle that Bridge should treat as the primary data file for JSON attributes. For more information, see [V2 Generic Bundles](#v2-generic-bundles).|
 |format|Either "v1\_legacy" or "v2\_generic". If not specified, defaults to "v1\_legacy"|
 |item|This should be filled in with the schema ID corresponding to the data in this bundle.|

--- a/_articles/schemas.md
+++ b/_articles/schemas.md
@@ -168,16 +168,26 @@ A schema revision can only be updated if the changes are backwards compatible. C
 
 * Schema name change.
 * min/maxAppVersion changes (see below).
-* Adding non-required fields.
-* Flipping required from true to false (but not vice versa).
+* Adding or re-ordering fields.
+* Upgrading a field from a legacy attachment field (blob, csv, json\_blob, or json\_table) to attachment\_v2 (but not vice versa).
+* Converting an int to a float (but not vice versa).
+* Converting a numeric type (int or float) to an inline\_json\_blob.
+* Converting a constrained string type (calendar\_date, float, inline\_json\_blob, int, time\_v2) to an unconstrained string (single\_choice, string), but not vice versa.
+* Converting between unconstrained string types (single\_choice or string).
+* Converting an int into a timestamp (but not vice versa).
+* Increasing the max length of a string (but not beyond 1000 characters).
+* Flipping required from true to false and vice versa.
 * Attachment metadata, such as fileExtension and mimeType.
 * Adding fields to multiChoiceAnswerList.
 * Flipping allowOtherChoices from false to true (but not vice versa).
 
 All other field changes are not compatible and require cutting a new schema revision. Common updates that are not compatible are (this is not an exhaustive list):
 
-* Changing a field type.
-* Changing a string field's maxLength, or changing its unboundedText.
+* Changing the schema type (from ios\_survey to ios\_data or vice versa).
+* Deleting a field.
+* Any other field type change.
+* Decreasing the max length of a string.
+* Flipping unboundedText from false to true or vice versa.
 
 ## Advanced Schema Attributes
 
@@ -199,11 +209,3 @@ Schemas can be linked to [Shared Modules](shared_modules.html). You generally do
 ### surveyGuid/CreatedOn
 
 Schemas can be linked to a Survey. You generally don't need to specify these yourself. Rather, Bridge will automatically create a schema from a survey when you publish the survey, and will fill in the surveyGuid (string) and surveyCreatedOn (ISO8601 timestamp) automatically.
-
-### published
-
-Schema revisions can be marked as published, by setting the published attribute to true. A published schema revision cannot be updated (but you can still bump the revision number and create a new revision).
-
-This is most useful when your schema is finalized and you want to ensure no further unintentional or untracked changes are made to it.
-
-Note that schemas do not need to be published to be made available to users.


### PR DESCRIPTION
Updates to docs:
* createdOn can now be used in V1 Legacy
* removed references to the published flag in schemas (no longer supported)
* updated list of allowed schema changes for more mutable schemas

Note: The schema changes referenced here are made available in https://github.com/Sage-Bionetworks/BridgePF/pull/1581, which at this time hasn't been pushed to prod yet.