### PR TITLE
Document Schema Width Limits

### DIFF
--- a/_articles/exporting_to_synapse.md
+++ b/_articles/exporting_to_synapse.md
@@ -92,6 +92,8 @@ Both the summary table and the health data tables contain a set of common fields
 |createdOnTimeZone|The participant's time zone, at the moment this data was measured, as reported by the app. This time zone is a string representation of a UTC offset. Combine this with createdOn to get a date-time with time zone information.|
 |userSharingScope|Participant's sharing scope, representing what level of sharing they have consented to. The two possible values are:<ul><li>**ALL\_QUALIFIED\_RESEARCHERS** - Participant has consented to sharing their data with any researcher who qualifies given the governance qualifications of this data set.</li><li>**SPONSORS\_AND\_PARTNERS** - Participant has consented only to sharing their data with the original study researchers and their affiliated research partners. This data should not be shared with anyone else.</li></ul>|
 |validationErrors|Error messages indicating that this health data record failed validation. For example, the record may have missing required fields, may have fields of the wrong type, or may have multiple-choice answers that are not allowed.|
+|substudyMemberships|A mapping from substudy ID to the participant's external ID. If the participant is not in that substudy, there will be no entry for that particular substudy. A user might be in a substudy without an external ID. The data is in the format "\|[substudyId1]=[externalId1]\|[substudyId2]=[externalId2]\|".|
+|rawData|The unencrypted raw data uploaded by the participant.|
 
 ### Summary Table
 

--- a/_articles/health_data_metadata.md
+++ b/_articles/health_data_metadata.md
@@ -55,3 +55,7 @@ Our above example would be converted to the following example table fragment:
 ### Conflicts in Field Names
 
 If for whatever reason, there is already a schema field named "metadata.[fieldName]", the field defined in the schema takes precedence over the metadata field. (This applies to both type and value.) A good way to remember this is "specific beats general".
+
+## Limits
+
+Metadata fields cannot create more than 20 columns or 2500 bytes. Note that the size limit is for space allocated, not for how much data is actually submitted. This also does not count against the column or size limit for schema fields. For more information, including column size by field type, see [Schema Limits](schemas.html#limits)


### PR DESCRIPTION
Also includes documentation for new common columns (substudyMemberships and rawData), Large Text Attachments, and best practices for choosing schema fields.

See https://sagebionetworks.jira.com/browse/BRIDGE-2397 and https://sagebionetworks.jira.com/wiki/spaces/BRIDGE/pages/763166825/Bridge+Table+Width+Limits