### PR TITLE
Add Participant Data documentation

### DIFF
--- a/_articles/participant_data.md
+++ b/_articles/participant_data.md
@@ -1,0 +1,40 @@
+---
+title: Participant Data
+layout: article
+---
+
+## Participant Data
+
+Participant data are non-time series reports which represent data that does not have a date or time associated with it. Participant data is retrievable with the participant's userId and/or identifier.
+
+Before, we used the Participant Report API to store non time-series information about Participants, using a dummy date of 2000-12-31. For example, Demographics and Engagement survey results in mPower 2.0 are stored this way.
+
+Using Participant Report API:
+
+```json
+{
+  "localDate": "2000-12-31",
+  "studyIds": {
+    "study1": "externalId1",
+    "study2": "externalId2"
+  },
+  "dateTime": "2000-12-31T06:50:21.650-07:00",
+  "data": "data"
+}
+```
+
+Using Participant Data API:
+
+```json
+{
+"identifier": "dataIdentifier",
+"data": "data"
+}
+```
+
+
+TODO is this a part of a larger migration to non-time series models?
+
+##API - TODO, link specifically to ParticipantData
+<dt><a href="/swagger-ui/index.html" target="_blank" rel="noopener">API Browser</a></dt>
+    <dd>Documents the URLs of the Participant Data API</dd>

--- a/_articles/participant_data.md
+++ b/_articles/participant_data.md
@@ -9,7 +9,7 @@ Participant data are non-time series reports which represent data that does not 
 
 Before, we used the Participant Report API to store non time-series information about Participants, using a dummy date of 2000-12-31. For example, Demographics and Engagement survey results in mPower 2.0 are stored this way.
 
-Using Participant Report API:
+###Using Participant Report API:
 
 ```json
 {
@@ -23,7 +23,7 @@ Using Participant Report API:
 }
 ```
 
-Using Participant Data API:
+###Using Participant Data API:
 
 ```json
 {
@@ -32,9 +32,7 @@ Using Participant Data API:
 }
 ```
 
+<!--TODO is this a part of a larger migration to non-time series models?-->
 
-TODO is this a part of a larger migration to non-time series models?
-
-##API - TODO, link specifically to ParticipantData
-<dt><a href="/swagger-ui/index.html" target="_blank" rel="noopener">API Browser</a></dt>
-    <dd>Documents the URLs of the Participant Data API</dd>
+##API <!--TODO, link specifically to ParticipantData-->
+Documentation of the URLs in the Participant Data API can be found <a href="/swagger-ui/index.html" target="_blank" rel="noopener">here</a>.


### PR DESCRIPTION
Here's what I have so far for this documentation, which doesn't seem like much. I still need to break through "writer's block" and also verify a couple of things: 
- Are these JSONs accurately representing Participant Reports and Participant Data? I left out the fields that were annotated with @JsonIgnore in the source code.
- Do we have more non-time series models in the works?
- ParticipantData isn't showing up in the swagger documentation right now, which I hope to link in this article.